### PR TITLE
[BUG] allow setting composer variable to nil

### DIFF
--- a/composer.lua
+++ b/composer.lua
@@ -1601,7 +1601,7 @@ lib.printMemUsage = function()
 end
 
 lib.setVariable = function( key, value )
-	if nil ~= key and nil ~= value then
+	if nil ~= key then
 		lib.variables[ key ] = value
 	end
 end


### PR DESCRIPTION
The composer API's setVariable method did not allow you to set a variable to nil, as I just found out while debugging my app. While I can probably work around it by setting to false instead, I have to be careful that other code in my app doesn't behave differently when given a boolean here, since I truly want to clear the variable completely in my use case. If this is considered a "feature" and you don't want to move forward with this fix, maybe we can get the docs updated with a new "gotcha?"

Signed-off-by: Mark Sandell <mdsandell@gmail.com>